### PR TITLE
Add Store and Wrap pages routing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div>
+      <h1>Page</h1>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -1,9 +1,69 @@
 import React from 'react';
+import {Car, Palette, Wrench} from "lucide-react";
+import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from "@/components/ui/card";
+import {Button} from "@/components/ui/button";
 
 const Page = () => {
   return (
-    <div>
-      <h1>Page</h1>
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 py-8">
+        <header className="pb-6 md:pb-8">
+          <h1 className="text-4xl md:text-6xl font-bold text-primary">Wraps</h1>
+        </header>
+        <h2 className="text-2xl md:text-3xl font-semibold mb-6 text-center">Choose Your Style</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <Card className="hover:shadow-lg transition-shadow duration-300">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Palette className="h-6 w-6"/>
+                Color Wraps
+              </CardTitle>
+              <CardDescription>Explore our range of vibrant color wraps</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p>Transform your vehicle with our high-quality color wraps. Choose from a wide spectrum of colors and
+                finishes.</p>
+            </CardContent>
+            <CardFooter>
+              <Button className="w-full">View Colors</Button>
+            </CardFooter>
+          </Card>
+
+          <Card className="hover:shadow-lg transition-shadow duration-300">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Wrench className="h-6 w-6"/>
+                Accessories
+              </CardTitle>
+              <CardDescription>Enhance your wrap with our accessories</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p>Complement your wrap with our selection of accessories. From trim kits to decals, we've got you
+                covered.</p>
+            </CardContent>
+            <CardFooter>
+              <Button className="w-full">Browse Accessories</Button>
+            </CardFooter>
+          </Card>
+
+          <Card className="hover:shadow-lg transition-shadow duration-300">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Car className="h-6 w-6"/>
+                Services
+              </CardTitle>
+              <CardDescription>Professional installation and maintenance</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p>Our expert team offers top-notch installation services and ongoing maintenance to keep your wrap
+                looking fresh.</p>
+            </CardContent>
+            <CardFooter>
+              <Button className="w-full">Our Services</Button>
+            </CardFooter>
+          </Card>
+        </div>
+      </main>
     </div>
   );
 };

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -38,14 +38,13 @@ const Page = () => {
               <CardDescription>Enhance your wrap with our accessories</CardDescription>
             </CardHeader>
             <CardContent>
-              <p>Complement your wrap with our selection of accessories. From trim kits to decals, we've got you
+              <p>Complement your wrap with our selection of accessories. From trim kits to decals, we&apos;ve got you
                 covered.</p>
             </CardContent>
             <CardFooter>
               <Button className="w-full">Browse Accessories</Button>
             </CardFooter>
           </Card>
-
           <Card className="hover:shadow-lg transition-shadow duration-300">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {Car, Palette, Wrench} from "lucide-react";
 import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from "@/components/ui/card";
-import {Button} from "@/components/ui/button";
+import {Button, buttonVariants} from "@/components/ui/button";
+import Link from "next/link";
 
 const Page = () => {
   return (
@@ -25,10 +26,9 @@ const Page = () => {
                 finishes.</p>
             </CardContent>
             <CardFooter>
-              <Button className="w-full">View Colors</Button>
+              <Link href="/store/wraps" className={buttonVariants({ className: "w-full" })}>View Colours</Link>
             </CardFooter>
           </Card>
-
           <Card className="hover:shadow-lg transition-shadow duration-300">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -8,7 +8,7 @@ const Page = () => {
     <div className="min-h-screen bg-background">
       <main className="container mx-auto px-4 py-8">
         <header className="pb-6 md:pb-8">
-          <h1 className="text-4xl md:text-6xl font-bold text-primary">Wraps</h1>
+          <h1 className="text-4xl md:text-5xl font-bold text-primary">Wraps</h1>
         </header>
         <h2 className="text-2xl md:text-3xl font-semibold mb-6 text-center">Choose Your Style</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/src/app/store/wraps/page.tsx
+++ b/src/app/store/wraps/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div>
+      <h1>Wraps Page</h1>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/store/wraps/page.tsx
+++ b/src/app/store/wraps/page.tsx
@@ -1,11 +1,46 @@
 import React from 'react';
+import {Card, CardContent, CardFooter} from "@/components/ui/card";
+import Image from "next/image"
+
+const wrapColors = [
+  {name: "Red Wrap", price: 50, image: "/placeholder.svg?height=200&width=300"},
+  {name: "Aqua", price: 65, image: "/placeholder.svg?height=200&width=300"},
+  {name: "Quartz White", price: 60, image: "/placeholder.svg?height=200&width=300"},
+  {name: "Blue", price: 50, image: "/placeholder.svg?height=200&width=300"},
+  {name: "Purple", price: 60, image: "/placeholder.svg?height=200&width=300"},
+  {name: "Deep Green", price: 60, image: "/placeholder.svg?height=200&width=300"},
+]
 
 const Page = () => {
   return (
-    <div>
-      <h1>Wraps Page</h1>
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 py-8">
+        <header className="pb-6 md:pb-8 text-center md:text-left">
+          <h1 className="text-4xl md:text-5xl font-bold pb-2">Wraps Colours</h1>
+          <p className="text-muted-foreground">Choose your Wrap.</p>
+        </header>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {wrapColors.map((color, index) => (
+            <Card key={index} className="overflow-hidden hover:ring-2 transition-shadow duration-300">
+              <CardContent className="p-0">
+                <Image
+                  src={color.image}
+                  alt={color.name}
+                  width={300}
+                  height={200}
+                  className="w-full h-48 object-cover"
+                />
+              </CardContent>
+              <CardFooter className="flex justify-between items-center p-4">
+                <h3 className="text-lg font-semibold">{color.name}</h3>
+                <p className="text-muted-foreground">$ {color.price}</p>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </main>
     </div>
-  );
+  )
 };
 
 export default Page;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -85,15 +85,21 @@ export default function NavBar() {
                           </Link>
                         </NavigationMenuLink>
                       </li>
-                      <ListItem href="/" title="Shop">
-                        View the store.
-                      </ListItem>
-                      <ListItem href="/" title="Accessories">
-                        View the accessories.
-                      </ListItem>
-                      <ListItem href="/services" title="Services">
-                        Explore our range of services.
-                      </ListItem>
+                      <Link href="/store">
+                        <ListItem title="Shop">
+                          View the store.
+                        </ListItem>
+                      </Link>
+                      <Link href="/">
+                        <ListItem title="Accessories">
+                          View the accessories.
+                        </ListItem>
+                      </Link>
+                      <Link href="/">
+                        <ListItem title="Services">
+                          Explore our range of services.
+                        </ListItem>
+                      </Link>
                     </ul>
                   </NavigationMenuContent>
                 </NavigationMenuItem>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -56,10 +56,12 @@ export default function NavBar() {
             <NavigationMenu>
               <NavigationMenuList>
                 <NavigationMenuItem>
-                  <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  <Link href="/">
+                    <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                       <Home className="mr-2 h-4 w-4"/>
                       Home
-                  </NavigationMenuLink>
+                    </NavigationMenuLink>
+                  </Link>
                 </NavigationMenuItem>
                 <NavigationMenuItem>
                   <NavigationMenuTrigger>
@@ -115,7 +117,7 @@ export default function NavBar() {
         </div>
         <div className="flex items-center space-x-4">
           <Button asChild className="hidden md:flex items-center justify-center">
-            <Link href="/">Contact Us</Link>
+            <Link href="#">Contact Us</Link>
           </Button>
           <button className="md:hidden" onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
             <Menu className="h-6 w-6"/>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -32,7 +32,7 @@ export default function NavBar() {
   }
 
   return (
-    <header className="sticky top-0 border-b bg-background z-50">
+    <nav className="sticky top-0 border-b bg-background z-50">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <div className="flex items-center space-x-4">
           <Link href="/" className="flex items-center space-x-2">
@@ -56,12 +56,10 @@ export default function NavBar() {
             <NavigationMenu>
               <NavigationMenuList>
                 <NavigationMenuItem>
-                  <Link href="/" passHref>
-                    <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                       <Home className="mr-2 h-4 w-4"/>
                       Home
-                    </NavigationMenuLink>
-                  </Link>
+                  </NavigationMenuLink>
                 </NavigationMenuItem>
                 <NavigationMenuItem>
                   <NavigationMenuTrigger>
@@ -74,7 +72,7 @@ export default function NavBar() {
                         <NavigationMenuLink asChild>
                           <Link
                             className={`flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md ${theme === 'dark' ? 'animate-gradient' : 'light-mode-animate-gradient'}`}
-                            href="/"
+                            href="/store/wraps"
                           >
                             <div className="mb-2 mt-4 text-lg font-medium">
                               Wrap Colours
@@ -128,7 +126,7 @@ export default function NavBar() {
       <div className="fixed bottom-4 right-4">
         <ThemeToggle/>
       </div>
-    </header>
+    </nav>
   )
 }
 

--- a/src/components/NavBarMobile.tsx
+++ b/src/components/NavBarMobile.tsx
@@ -61,15 +61,21 @@ export default function NavBarMobile({isMobileMenuOpen}: MobileMenuProps) {
                     </Link>
                   </NavigationMenuLink>
                 </li>
-                <ListItem href="/" title="Shop">
-                  View the store.
-                </ListItem>
-                <ListItem href="/" title="Accessories">
-                  View the accessories.
-                </ListItem>
-                <ListItem href="/services" title="Services">
-                  Explore our range of services.
-                </ListItem>
+                <Link href="/store">
+                  <ListItem title="Shop">
+                    View the store.
+                  </ListItem>
+                </Link>
+                <Link href="/">
+                  <ListItem title="Accessories">
+                    View the accessories.
+                  </ListItem>
+                </Link>
+                <Link href="/">
+                  <ListItem title="Services">
+                    Explore our range of services.
+                  </ListItem>
+                </Link>
               </ul>
             </NavigationMenuContent>
           </NavigationMenuItem>

--- a/src/components/NavBarMobile.tsx
+++ b/src/components/NavBarMobile.tsx
@@ -75,7 +75,7 @@ export default function NavBarMobile({isMobileMenuOpen}: MobileMenuProps) {
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <Link href="/" passHref>
+            <Link href="#" passHref>
               <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                 <Palette className="mr-2 h-4 w-4"/>
                 Colour Picker

--- a/src/components/NavBarMobile.tsx
+++ b/src/components/NavBarMobile.tsx
@@ -27,6 +27,7 @@ export default function NavBarMobile({isMobileMenuOpen}: MobileMenuProps) {
     return null;
   }
 
+  // TODO: make navbar close every time a link is clicked
   return (
     <div className="md:hidden flex flex-col items-center text-center pull-down z-40">
       <NavigationMenu className="pb-2">
@@ -50,7 +51,7 @@ export default function NavBarMobile({isMobileMenuOpen}: MobileMenuProps) {
                   <NavigationMenuLink asChild>
                     <Link
                       className={`flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md ${theme === 'dark' ? 'animate-gradient' : 'light-mode-animate-gradient'}`}
-                      href="/"
+                      href="/store/wraps"
                     >
                       <div className="mb-2 mt-4 text-lg font-medium">
                         Wrap Colours
@@ -61,21 +62,15 @@ export default function NavBarMobile({isMobileMenuOpen}: MobileMenuProps) {
                     </Link>
                   </NavigationMenuLink>
                 </li>
-                <Link href="/store">
-                  <ListItem title="Shop">
-                    View the store.
-                  </ListItem>
-                </Link>
-                <Link href="/">
-                  <ListItem title="Accessories">
-                    View the accessories.
-                  </ListItem>
-                </Link>
-                <Link href="/">
-                  <ListItem title="Services">
-                    Explore our range of services.
-                  </ListItem>
-                </Link>
+                <ListItem href="/store" title="Shop">
+                  View the store.
+                </ListItem>
+                <ListItem href="/" title="Accessories">
+                  View the accessories.
+                </ListItem>
+                <ListItem href="/services" title="Services">
+                  Explore our range of services.
+                </ListItem>
               </ul>
             </NavigationMenuContent>
           </NavigationMenuItem>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
This pull request includes significant updates to the store pages and navigation components to enhance the user experience and navigation flow. The most important changes include the addition of new pages for displaying wrap colors and updates to the navigation links.

### Store Pages Enhancements:

* [`src/app/store/page.tsx`](diffhunk://#diff-0c52736706114a3852cc694d6b5eb0fa528c5e2965996ff59bffacbb2bb3e7e4R1-R71): Added a new page to showcase different wrap styles, including color wraps, accessories, and services.
* [`src/app/store/wraps/page.tsx`](diffhunk://#diff-546363fce62a3c01f8cafd32149cb14a4a51e645c5ecffe50196ef8aeb12b841R1-R46): Added a new page to display available wrap colors with their respective prices and images.

### Navigation Improvements:

* [`src/components/NavBar.tsx`](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL35-R35): Updated navigation links to point to the new store pages and changed the `header` element to a `nav` element for semantic correctness. [[1]](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL35-R35) [[2]](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL59-R59) [[3]](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL77-R77) [[4]](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL88-R102) [[5]](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL114-R120) [[6]](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL125-R131)
* [`src/components/NavBarMobile.tsx`](diffhunk://#diff-c2758090105b286508c6a56286ab13168ddfea92ff6a450776e005d35272cfabR30): Updated mobile navigation links to match the new structure and added a TODO comment to close the navbar when a link is clicked. [[1]](diffhunk://#diff-c2758090105b286508c6a56286ab13168ddfea92ff6a450776e005d35272cfabR30) [[2]](diffhunk://#diff-c2758090105b286508c6a56286ab13168ddfea92ff6a450776e005d35272cfabL53-R54) [[3]](diffhunk://#diff-c2758090105b286508c6a56286ab13168ddfea92ff6a450776e005d35272cfabL64-R65) [[4]](diffhunk://#diff-c2758090105b286508c6a56286ab13168ddfea92ff6a450776e005d35272cfabL77-R78)