### PR TITLE
Colour Picker Page

### DIFF
--- a/src/app/colour_picker/page.tsx
+++ b/src/app/colour_picker/page.tsx
@@ -81,7 +81,7 @@ const ColorPickerPage = () => {
                 fill
                 className="object-contain"
               />
-              // TODO: redo this later with a proper overlay, once we have the actual images
+              {/*// TODO: redo this later with a proper overlay, once we have the actual images*/}
               <div
                 className="absolute inset-0 opacity-50"
                 style={{ backgroundColor: selectedColor.name.toLowerCase().replace(" ", "") }}

--- a/src/app/colour_picker/page.tsx
+++ b/src/app/colour_picker/page.tsx
@@ -81,6 +81,7 @@ const ColorPickerPage = () => {
                 fill
                 className="object-contain"
               />
+              // TODO: redo this later with a proper overlay, once we have the actual images
               <div
                 className="absolute inset-0 opacity-50"
                 style={{ backgroundColor: selectedColor.name.toLowerCase().replace(" ", "") }}

--- a/src/app/colour_picker/page.tsx
+++ b/src/app/colour_picker/page.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto px-4 py-8">
+        <header className="pb-6 md:pb-8 text-center md:text-left">
+          <h1 className="text-4xl md:text-5xl font-bold pb-2">Colour Picker</h1>
+          <p className="text-muted-foreground">Pick your favourite colour.</p>
+        </header>
+      </main>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/colour_picker/page.tsx
+++ b/src/app/colour_picker/page.tsx
@@ -1,16 +1,103 @@
-import React from 'react';
+"use client"
 
-const Page = () => {
+import { useState } from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import Image from "next/image"
+
+const wrapColors = [
+  { name: "Deep Blue", image: "/placeholder.svg?height=100&width=100&text=Deep+Blue" },
+  { name: "Sky Blue", image: "/placeholder.svg?height=100&width=100&text=Sky+Blue" },
+  { name: "Royal Purple", image: "/placeholder.svg?height=100&width=100&text=Royal+Purple" },
+  { name: "Sunset Orange", image: "/placeholder.svg?height=100&width=100&text=Sunset+Orange" },
+  { name: "Fiery Red", image: "/placeholder.svg?height=100&width=100&text=Fiery+Red" },
+  { name: "Electric Blue", image: "/placeholder.svg?height=100&width=100&text=Electric+Blue" },
+]
+
+const carModels = [
+  { name: "Sports Car", image: "/placeholder.svg?height=300&width=500&text=Sports+Car" },
+  { name: "SUV", image: "/placeholder.svg?height=300&width=500&text=SUV" },
+  { name: "Sedan", image: "/placeholder.svg?height=300&width=500&text=Sedan" },
+]
+
+const ColorPickerPage = () => {
+  const [selectedColor, setSelectedColor] = useState(wrapColors[0])
+  const [currentCarIndex, setCurrentCarIndex] = useState(0)
+
+  const nextCar = () => {
+    setCurrentCarIndex((prevIndex) => (prevIndex + 1) % carModels.length)
+  }
+
+  const prevCar = () => {
+    setCurrentCarIndex((prevIndex) => (prevIndex - 1 + carModels.length) % carModels.length)
+  }
+
   return (
-    <div className="min-h-screen bg-background">
-      <main className="container mx-auto px-4 py-8">
-        <header className="pb-6 md:pb-8 text-center md:text-left">
-          <h1 className="text-4xl md:text-5xl font-bold pb-2">Colour Picker</h1>
-          <p className="text-muted-foreground">Pick your favourite colour.</p>
-        </header>
-      </main>
+    <div className="h-[80vh] flex flex-col">
+      <div className="container mx-auto px-4 py-8 flex-grow flex flex-col overflow-hidden">
+        <h1 className="text-4xl font-bold mb-8 text-center">Car Wrap Color Picker</h1>
+        <div className="flex-grow flex flex-col lg:flex-row gap-8 overflow-hidden">
+          <div className="lg:w-1/2 flex flex-col overflow-hidden">
+            <div className="flex-grow grid grid-cols-2 md:grid-cols-3 gap-4 overflow-y-auto p-1">
+              {wrapColors.map((color) => (
+                <Card
+                  key={color.name}
+                  className={`cursor-pointer transition-all ${
+                    selectedColor.name === color.name
+                      ? "ring-2 ring-primary ring-offset-2 ring-offset-background"
+                      : ""
+                  }`}
+                  onClick={() => setSelectedColor(color)}
+                >
+                  <CardContent className="p-2 md:p-4">
+                    <div className="relative aspect-square rounded-md overflow-hidden">
+                      <Image
+                        src={color.image}
+                        alt={color.name}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <p className="text-center mt-2 text-sm md:text-base">{color.name}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+            <div className="flex justify-center gap-4 mt-4">
+              <Button variant="outline" size="icon">
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon">
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+          <div className="lg:w-1/2 flex flex-col overflow-hidden">
+            <div className="flex-grow relative">
+              <Image
+                src={carModels[currentCarIndex].image}
+                alt={carModels[currentCarIndex].name}
+                fill
+                className="object-contain"
+              />
+              <div
+                className="absolute inset-0 opacity-50"
+                style={{ backgroundColor: selectedColor.name.toLowerCase().replace(" ", "") }}
+              ></div>
+              <Button variant="outline" size="icon" className="absolute left-4 top-1/2 transform -translate-y-1/2" onClick={prevCar}>
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon" className="absolute right-4 top-1/2 transform -translate-y-1/2" onClick={nextCar}>
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+            <p className="text-center mt-4">Selected: {selectedColor.name} on {carModels[currentCarIndex].name}</p>
+          </div>
+        </div>
+      </div>
     </div>
-  );
-};
+  )
+}
 
-export default Page;
+export default ColorPickerPage;

--- a/src/app/store/wraps/page.tsx
+++ b/src/app/store/wraps/page.tsx
@@ -11,7 +11,7 @@ const wrapColors = [
   {name: "Deep Green", price: 60, image: "/placeholder.svg?height=200&width=300"},
 ]
 
-const Page = () => {
+const WrapsPage = () => {
   return (
     <div className="min-h-screen bg-background">
       <main className="container mx-auto px-4 py-8">
@@ -43,4 +43,4 @@ const Page = () => {
   )
 };
 
-export default Page;
+export default WrapsPage;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -90,7 +90,7 @@ export default function NavBar() {
                   </NavigationMenuContent>
                 </NavigationMenuItem>
                 <NavigationMenuItem>
-                  <Link href="/" passHref>
+                  <Link href="/colour_picker" passHref>
                     <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                       <Palette className="mr-2 h-4 w-4"/>
                       Colour Picker

--- a/src/components/NavBarMobile.tsx
+++ b/src/components/NavBarMobile.tsx
@@ -75,7 +75,7 @@ export default function NavBarMobile({isMobileMenuOpen}: MobileMenuProps) {
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <Link href="#" passHref>
+            <Link href="/colour_picker" passHref>
               <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                 <Palette className="mr-2 h-4 w-4"/>
                 Colour Picker


### PR DESCRIPTION
This pull request introduces a new color picker page for car wraps and updates navigation links to include the new page. Additionally, it includes a minor renaming change in the wraps store page.

New Color Picker Page:

* [`src/app/colour_picker/page.tsx`](diffhunk://#diff-7d57504c5b74f00f129bcf1459205c1f243bef2f735ea550cb2af5570bd01a39R1-R104): Added a new color picker page that allows users to select car wrap colors and view them on different car models.

Navigation Updates:

* [`src/components/NavBar.tsx`](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL93-R93): Updated the navigation link to point to the new color picker page.
* [`src/components/NavBarMobile.tsx`](diffhunk://#diff-c2758090105b286508c6a56286ab13168ddfea92ff6a450776e005d35272cfabL78-R78): Updated the mobile navigation link to point to the new color picker page.

Minor Renaming:

* [`src/app/store/wraps/page.tsx`](diffhunk://#diff-546363fce62a3c01f8cafd32149cb14a4a51e645c5ecffe50196ef8aeb12b841L14-R14): Renamed the `Page` component to `WrapsPage` for better clarity. [[1]](diffhunk://#diff-546363fce62a3c01f8cafd32149cb14a4a51e645c5ecffe50196ef8aeb12b841L14-R14) [[2]](diffhunk://#diff-546363fce62a3c01f8cafd32149cb14a4a51e645c5ecffe50196ef8aeb12b841L46-R46)